### PR TITLE
Closes threadpool to prevent threads leaking

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,37 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        python -m pytest --cov=mgzip
+

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,33 +5,34 @@ name: Python application
 
 on:
   push:
-    branches: [ master ]
+  #branches: [ master ]
   pull_request:
-    branches: [ master ]
+    #branches: [ master ]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        python -m pytest --cov=mgzip
-
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          python -m pytest -v --cov=mgzip

--- a/mgzip/multiProcGzip.py
+++ b/mgzip/multiProcGzip.py
@@ -452,6 +452,9 @@ class MultiGzipFile(GzipFile):
             if myfileobj:
                 self.myfileobj = None
                 myfileobj.close()
+            if self.mode == WRITE:
+                self.pool.close()
+                self.pool.join()
 
     def flush(self):
         self._check_not_closed()

--- a/mgzip/multiProcGzip.py
+++ b/mgzip/multiProcGzip.py
@@ -452,9 +452,12 @@ class MultiGzipFile(GzipFile):
             if myfileobj:
                 self.myfileobj = None
                 myfileobj.close()
+                  
             if self.mode == WRITE:
                 self.pool.close()
                 self.pool.join()
+            elif self.mode == READ:
+                self.raw.close()
 
     def flush(self):
         self._check_not_closed()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-cov
+pytest-xdist
+pylint

--- a/tests/test_mgzip.py
+++ b/tests/test_mgzip.py
@@ -39,3 +39,15 @@ def test_read_rb(tmpdir):
     assert file_content == DATA1 * 500
 
 
+def test_pool_close(tmpdir):
+    
+    s = b"1234567890" * 1000
+    filename = os.path.join(tmpdir, "test.gz")
+    fh = mgzip.open(filename, 'wb', compresslevel=6, thread=4, blocksize=128)
+    fh.write(s)
+    assert repr(fh.pool) == "<multiprocessing.pool.ThreadPool state=RUN pool_size=4>"
+    fh.close()
+    assert fh.fileobj is None
+    assert fh.myfileobj is None
+    assert fh.pool_result == []
+    assert repr(fh.pool) == "<multiprocessing.pool.ThreadPool state=CLOSE pool_size=4>"

--- a/tests/test_mgzip.py
+++ b/tests/test_mgzip.py
@@ -1,5 +1,6 @@
-import pytest
+import sys
 import os
+import pytest
 import mgzip
 import gzip
 
@@ -9,21 +10,22 @@ Simple is better than complex.
 Complex is better than complicated.
 """
 
+
 def test_write_wb(tmpdir):
 
     filename = os.path.join(tmpdir, "test.gz")
-    with mgzip.open(filename, 'wb', compresslevel=6) as f1:
+    with mgzip.open(filename, "wb", compresslevel=6) as f1:
         f1.write(DATA1 * 50)
         # Try flush and fileno.
         f1.flush()
         f1.fileno()
-        if hasattr(os, 'fsync'):
+        if hasattr(os, "fsync"):
             os.fsync(f1.fileno())
         f1.close()
     f1.close()
 
     assert os.path.exists(filename)
-    with gzip.open(filename, 'rb') as f2:
+    with gzip.open(filename, "rb") as f2:
         file_content = f2.read()
     assert file_content == DATA1 * 50
 
@@ -31,23 +33,36 @@ def test_write_wb(tmpdir):
 def test_read_rb(tmpdir):
 
     filename = os.path.join(tmpdir, "test.gz")
-    with gzip.open(filename, 'wb') as f1:
+    with gzip.open(filename, "wb") as f1:
         f1.write(DATA1 * 500)
 
-    with mgzip.open(filename, 'rb') as f2:
+    with mgzip.open(filename, "rb") as f2:
         file_content = f2.read()
     assert file_content == DATA1 * 500
 
 
 def test_pool_close(tmpdir):
-    
-    s = b"1234567890" * 1000
+
     filename = os.path.join(tmpdir, "test.gz")
-    fh = mgzip.open(filename, 'wb', compresslevel=6, thread=4, blocksize=128)
-    fh.write(s)
-    assert repr(fh.pool) == "<multiprocessing.pool.ThreadPool state=RUN pool_size=4>"
+    fh = mgzip.open(filename, "wb", compresslevel=6, thread=4, blocksize=128)
+    fh.write(DATA1 * 500)
+    if sys.version_info >= (3, 8):
+        assert (
+            repr(fh.pool) == "<multiprocessing.pool.ThreadPool state=RUN pool_size=4>"
+        )
     fh.close()
     assert fh.fileobj is None
     assert fh.myfileobj is None
     assert fh.pool_result == []
-    assert repr(fh.pool) == "<multiprocessing.pool.ThreadPool state=CLOSE pool_size=4>"
+    if sys.version_info >= (3, 8):
+        assert (
+            repr(fh.pool) == "<multiprocessing.pool.ThreadPool state=CLOSE pool_size=4>"
+        )
+    if sys.version_info >= (3, 7):
+        with pytest.raises(ValueError) as excinfo:
+            fh.pool.apply(print, ("x",))
+        assert "Pool not running" in str(excinfo.value)
+    else:
+        with pytest.raises(AssertionError) as excinfo:
+            fh.pool.apply(print, ("x",))
+        assert "" == str(excinfo.value)

--- a/tests/test_mgzip.py
+++ b/tests/test_mgzip.py
@@ -1,0 +1,41 @@
+import pytest
+import os
+import mgzip
+import gzip
+
+DATA1 = b""""Beautiful is better than ugly.
+Explicit is better than implicit.
+Simple is better than complex.
+Complex is better than complicated.
+"""
+
+def test_write_wb(tmpdir):
+
+    filename = os.path.join(tmpdir, "test.gz")
+    with mgzip.open(filename, 'wb', compresslevel=6) as f1:
+        f1.write(DATA1 * 50)
+        # Try flush and fileno.
+        f1.flush()
+        f1.fileno()
+        if hasattr(os, 'fsync'):
+            os.fsync(f1.fileno())
+        f1.close()
+    f1.close()
+
+    assert os.path.exists(filename)
+    with gzip.open(filename, 'rb') as f2:
+        file_content = f2.read()
+    assert file_content == DATA1 * 50
+
+
+def test_read_rb(tmpdir):
+
+    filename = os.path.join(tmpdir, "test.gz")
+    with gzip.open(filename, 'wb') as f1:
+        f1.write(DATA1 * 500)
+
+    with mgzip.open(filename, 'rb') as f2:
+        file_content = f2.read()
+    assert file_content == DATA1 * 500
+
+


### PR DESCRIPTION
Fixes #11 for the WRITE case by calling pool.close() and pool.join() 


some  tests using pytest that just check that 
- a file created by mgzip can be read by normal gzip
- a file created by normal gzip can be read by mgzip
- checks that the pool has been closed by checking for an error when calling pool.apply()

```
thughes@silicon [0] $ pytest -v --cov mgzip
========================= test session starts =========================
platform linux -- Python 3.6.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/thughes/git/mgzip/.venv/bin/python3.6
cachedir: .pytest_cache
rootdir: /home/thughes/git/mgzip
plugins: cov-2.11.1
collected 3 items                                                     

tests/test_mgzip.py::test_write_wb PASSED                       [ 33%]
tests/test_mgzip.py::test_read_rb PASSED                        [ 66%]
tests/test_mgzip.py::test_pool_close PASSED                     [100%]

----------- coverage: platform linux, python 3.6.9-final-0 -----------
Name                     Stmts   Miss  Cover
--------------------------------------------
mgzip/__init__.py            3      0   100%
mgzip/__main__.py           23     23     0%
mgzip/multiProcGzip.py     414    181    56%
--------------------------------------------
TOTAL                      440    204    54%


========================== 3 passed in 0.30s ==========================
```

Also adds a github action to test any pull requests https://github.com/timhughes/mgzip/actions/runs/513701311

